### PR TITLE
Improve ML Algorithm Runtime

### DIFF
--- a/src/main/java/com/google/sps/algorithms/MatchQuery.java
+++ b/src/main/java/com/google/sps/algorithms/MatchQuery.java
@@ -8,26 +8,22 @@ import com.google.sps.data.UserRepository;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import com.google.sps.data.SessionContext;
-import java.util.*;
+import java.util.Map;
 
 public final class MatchQuery {
-
-    // private SessionContext sessionContext = SessionContext.getInstance();
-    
+ 
   /**
-  * This method takes a MatchRequest and a Collection of users that are already saved and returns 
+  * This method takes a current User, MatchRequest, and a Collection of users that are already saved and returns 
   * all Users in the User Repository that match the criteria in MatchRequest AND are not already
   * saved in the userSavedMatches collection.
   */
-  public Collection<User> query(Map<String, Integer> savedBioCount, MatchRequest request, Collection<User> userSavedMatches) {
+  public Collection<User> query(User currentUser, MatchRequest request, Collection<User> userSavedMatches) {
     PersistentUserRepository userRepository = PersistentUserRepository.getInstance();
-    return query(savedBioCount, request, userSavedMatches, userRepository);
+    return query(currentUser, request, userSavedMatches, userRepository);
   }
 
   //overload of query allows UserRepository to be passed in for testing
-  public Collection<User> query(Map<String, Integer> savedBioCount, MatchRequest request, Collection<User> userSavedMatches, UserRepository userRepository) {
+  public Collection<User> query(User currentUser, MatchRequest request, Collection<User> userSavedMatches, UserRepository userRepository) {
       
     Collection<User> allUsers = userRepository.getAllUsers();
     Collection<User> mentorMatches = new ArrayList<User>();
@@ -42,16 +38,13 @@ public final class MatchQuery {
     for(User potentialMentor : allUsers) {
         Collection<String> mentorSpecialties = potentialMentor.getSpecialties();
 
-        //see if new mentor is not already saved AND contains correct criteria
-        if(!(userSavedMatches.contains(potentialMentor)) && (mentorSpecialties.contains(matchCriteria))) {
+        //see if new mentor is not same as logged in user AND is not already saved AND contains correct criteria
+        if(!(potentialMentor.equals(currentUser)) && !(userSavedMatches.contains(potentialMentor)) && (mentorSpecialties.contains(matchCriteria))) {
             mentorMatches.add(potentialMentor);
         }
     }
 
-    // User currentUser = sessionContext.getLoggedInUser();
-
-    List<User> rankedMatches = MatchRanking.rankMatches(savedBioCount, mentorMatches);
-    
+    List<User> rankedMatches = MatchRanking.rankMatches(currentUser.getBioMap(), mentorMatches);
     return rankedMatches;
   }
 

--- a/src/main/java/com/google/sps/algorithms/MatchQuery.java
+++ b/src/main/java/com/google/sps/algorithms/MatchQuery.java
@@ -9,20 +9,25 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import com.google.sps.data.SessionContext;
+import java.util.*;
+
 public final class MatchQuery {
+
+    // private SessionContext sessionContext = SessionContext.getInstance();
     
   /**
   * This method takes a MatchRequest and a Collection of users that are already saved and returns 
   * all Users in the User Repository that match the criteria in MatchRequest AND are not already
   * saved in the userSavedMatches collection.
   */
-  public Collection<User> query(MatchRequest request, Collection<User> userSavedMatches) {
+  public Collection<User> query(Map<String, Integer> savedBioCount, MatchRequest request, Collection<User> userSavedMatches) {
     PersistentUserRepository userRepository = PersistentUserRepository.getInstance();
-    return query(request, userSavedMatches, userRepository);
+    return query(savedBioCount, request, userSavedMatches, userRepository);
   }
 
   //overload of query allows UserRepository to be passed in for testing
-  public Collection<User> query(MatchRequest request, Collection<User> userSavedMatches, UserRepository userRepository) {
+  public Collection<User> query(Map<String, Integer> savedBioCount, MatchRequest request, Collection<User> userSavedMatches, UserRepository userRepository) {
       
     Collection<User> allUsers = userRepository.getAllUsers();
     Collection<User> mentorMatches = new ArrayList<User>();
@@ -43,7 +48,9 @@ public final class MatchQuery {
         }
     }
 
-    List<User> rankedMatches = MatchRanking.rankMatches(userSavedMatches, allUsers, mentorMatches);
+    // User currentUser = sessionContext.getLoggedInUser();
+
+    List<User> rankedMatches = MatchRanking.rankMatches(savedBioCount, mentorMatches);
     
     return rankedMatches;
   }

--- a/src/main/java/com/google/sps/algorithms/MatchRanking.java
+++ b/src/main/java/com/google/sps/algorithms/MatchRanking.java
@@ -1,5 +1,6 @@
 package com.google.sps.algorithms;
 
+import com.google.sps.data.User;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -8,15 +9,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.sps.data.User;
-
 public final class MatchRanking {
 
     private static final double EPSILON = 0.000001;
     private static Map<String, Integer> allUserWordCount = new HashMap<String, Integer>();
 
     /**
-    * Function takes collection of user's saved matches, all users, and new match users and 
+    * Function takes user's saved matches word count map and new match users and 
     * returns a list of the new matches as users in ranked order from highest to lowest score 
     * (higher score = more likely that the user will select it).
     */
@@ -34,25 +33,10 @@ public final class MatchRanking {
     }
 
     /**
-    * Function that takes the three User collections and returns a map with each new match mapped to its score.
+    * Function that returns a map with each new match mapped to its score.
     */
     private static Map<User, Double> scoreNewMatches(Map<String, Integer> savedMatchesWordCount, Collection<User> newMatches) {
-        // Collection<String> savedMatchBios = new ArrayList<String>();
-        // for(User user : savedMatches) {
-        //     savedMatchBios.add(user.getBio());
-        // }
-
-        // Collection<String> allUserBios = new ArrayList<String>();
-        // for(User user : allUsers) {
-        //     allUserBios.add(user.getBio());
-        // }
-
-        //count words in all of the saved match bios
-        // Map<String, Integer> savedMatchesWordCount = countWordInstances(savedMatchBios);
-
-        //count words in all of the user bios
-        // Map<String, Integer> allUserWordCount = countWordInstances(allUserBios);
-
+        
         //calculate score for each new match bio
         Map<User, Double> newMatchScores = new HashMap<User, Double>();
         for(User newMatch : newMatches) {
@@ -64,7 +48,7 @@ public final class MatchRanking {
     }
 
     /**
-    * Function that takes the map of users to their scores and returns a list of the users in sorted order from highest to lowest score.
+    * Function that returns a list of the users in sorted order from highest to lowest score.
     */
     private static List<User> sortUsersByScore(Map<User, Double> newMatchScores) {
         List<User> orderedUsers = new ArrayList<User>();
@@ -151,21 +135,10 @@ public final class MatchRanking {
     * Called everytime a user adds a new bio, this updates the private map storing word counts for all users.
     */
     public static void addToAllUserWordCount(String newBio) {
-         addNewBioToMapCount(newBio, allUserWordCount);
-
-        // String[] bioWords = newBio.toLowerCase().split("\\W+");
-            
-        // //add each word in bio to map
-        // for(String word : bioWords) {
-        //     if(allUserWordCount.containsKey(word)) {
-        //         Integer oldCount = allUserWordCount.get(word);
-        //         allUserWordCount.put(word, oldCount + 1); 
-        //     } else {
-        //         allUserWordCount.put(word, 1);
-        //     }
-        // }
+        addNewBioToMapCount(newBio, allUserWordCount);
     }
 
+    //overload of addToAllUserWordCount for testing
     public static void addNewBioToMapCount(String newBio, Map<String, Integer> countMap) {
         String[] bioWords = newBio.toLowerCase().split("\\W+");
             

--- a/src/main/java/com/google/sps/algorithms/MatchRanking.java
+++ b/src/main/java/com/google/sps/algorithms/MatchRanking.java
@@ -13,14 +13,15 @@ import com.google.sps.data.User;
 public final class MatchRanking {
 
     private static final double EPSILON = 0.000001;
+    private static Map<String, Integer> allUserWordCount = new HashMap<String, Integer>();
 
     /**
     * Function takes collection of user's saved matches, all users, and new match users and 
     * returns a list of the new matches as users in ranked order from highest to lowest score 
     * (higher score = more likely that the user will select it).
     */
-    public static List<User> rankMatches(Collection<User> savedMatches, Collection<User> allUsers, Collection<User> newMatches) {
-        Map<User, Double> newMatchScores = scoreNewMatches(savedMatches, allUsers, newMatches);
+    public static List<User> rankMatches(Map<String, Integer> savedMatchesMap, Collection<User> newMatches) {
+        Map<User, Double> newMatchScores = scoreNewMatches(savedMatchesMap, newMatches);
         return sortUsersByScore(newMatchScores);
     }
 
@@ -28,29 +29,29 @@ public final class MatchRanking {
     /**
     * Returns a map of User scores - should only be used in testing. 
     */
-    public static Map<User, Double> getMatchScores(Collection<User> savedMatches, Collection<User> allUsers, Collection<User> newMatches) {
-        return scoreNewMatches(savedMatches, allUsers, newMatches);
+    public static Map<User, Double> getMatchScores(Map<String, Integer> savedMatchesMap, Collection<User> newMatches) {
+        return scoreNewMatches(savedMatchesMap, newMatches);
     }
 
     /**
     * Function that takes the three User collections and returns a map with each new match mapped to its score.
     */
-    private static Map<User, Double> scoreNewMatches(Collection<User> savedMatches, Collection<User> allUsers, Collection<User> newMatches) {
-        Collection<String> savedMatchBios = new ArrayList<String>();
-        for(User user : savedMatches) {
-            savedMatchBios.add(user.getBio());
-        }
+    private static Map<User, Double> scoreNewMatches(Map<String, Integer> savedMatchesWordCount, Collection<User> newMatches) {
+        // Collection<String> savedMatchBios = new ArrayList<String>();
+        // for(User user : savedMatches) {
+        //     savedMatchBios.add(user.getBio());
+        // }
 
-        Collection<String> allUserBios = new ArrayList<String>();
-        for(User user : allUsers) {
-            allUserBios.add(user.getBio());
-        }
+        // Collection<String> allUserBios = new ArrayList<String>();
+        // for(User user : allUsers) {
+        //     allUserBios.add(user.getBio());
+        // }
 
         //count words in all of the saved match bios
-        Map<String, Integer> savedMatchesWordCount = countWordInstances(savedMatchBios);
+        // Map<String, Integer> savedMatchesWordCount = countWordInstances(savedMatchBios);
 
         //count words in all of the user bios
-        Map<String, Integer> allUserWordCount = countWordInstances(allUserBios);
+        // Map<String, Integer> allUserWordCount = countWordInstances(allUserBios);
 
         //calculate score for each new match bio
         Map<User, Double> newMatchScores = new HashMap<User, Double>();
@@ -144,6 +145,39 @@ public final class MatchRanking {
             }
         }
         return wordCounts;
+    }
+
+    /**
+    * Called everytime a user adds a new bio, this updates the private map storing word counts for all users.
+    */
+    public static void addToAllUserWordCount(String newBio) {
+         addNewBioToMapCount(newBio, allUserWordCount);
+
+        // String[] bioWords = newBio.toLowerCase().split("\\W+");
+            
+        // //add each word in bio to map
+        // for(String word : bioWords) {
+        //     if(allUserWordCount.containsKey(word)) {
+        //         Integer oldCount = allUserWordCount.get(word);
+        //         allUserWordCount.put(word, oldCount + 1); 
+        //     } else {
+        //         allUserWordCount.put(word, 1);
+        //     }
+        // }
+    }
+
+    public static void addNewBioToMapCount(String newBio, Map<String, Integer> countMap) {
+        String[] bioWords = newBio.toLowerCase().split("\\W+");
+            
+        //add each word in bio to map
+        for(String word : bioWords) {
+            if(countMap.containsKey(word)) {
+                Integer oldCount = countMap.get(word);
+                countMap.put(word, oldCount + 1); 
+            } else {
+                countMap.put(word, 1);
+            }
+        }
     }
 
 }

--- a/src/main/java/com/google/sps/data/User.java
+++ b/src/main/java/com/google/sps/data/User.java
@@ -6,9 +6,9 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.sps.algorithms.MatchRanking;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
-
-import java.util.*;
+import java.util.Map;
 
 public final class User {
   public static enum ProfileType {
@@ -26,7 +26,6 @@ public final class User {
   private Collection<String> specialties;
   private String userBio;
   private Map<String, Integer> savedMatchWordCount;
-
 
   public User(String name) {
     this.name = name;

--- a/src/main/java/com/google/sps/data/User.java
+++ b/src/main/java/com/google/sps/data/User.java
@@ -152,22 +152,24 @@ public final class User {
       return userBio;
   }
 
+  //adds word count of bio when user saves a new match
   public void addNewBioToMapCount(String newBio) {
-        String[] bioWords = newBio.toLowerCase().split("\\W+");
+    String[] bioWords = newBio.toLowerCase().split("\\W+");
             
-        //add each word in bio to map
-        for(String word : bioWords) {
-            if(savedMatchWordCount.containsKey(word)) {
-                Integer oldCount = savedMatchWordCount.get(word);
-                savedMatchWordCount.put(word, oldCount + 1); 
-            } else {
-                savedMatchWordCount.put(word, 1);
-            }
+    //add each word in bio to map
+    for(String word : bioWords) {
+        if(savedMatchWordCount.containsKey(word)) {
+            Integer oldCount = savedMatchWordCount.get(word);
+            savedMatchWordCount.put(word, oldCount + 1); 
+        } else {
+            savedMatchWordCount.put(word, 1);
         }
     }
+  }
 
-    public Map<String, Integer> getBioMap() {
-        return savedMatchWordCount;
-    }
+  //get the saved bio map for user
+  public Map<String, Integer> getBioMap() {
+    return savedMatchWordCount;
+  }
 
 }

--- a/src/main/java/com/google/sps/data/User.java
+++ b/src/main/java/com/google/sps/data/User.java
@@ -4,9 +4,11 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.sps.algorithms.MatchRanking;
 import java.util.Collection;
 import java.util.HashSet;
 
+import java.util.*;
 
 public final class User {
   public static enum ProfileType {
@@ -23,12 +25,16 @@ public final class User {
   private String school;
   private Collection<String> specialties;
   private String userBio;
+  private Map<String, Integer> savedMatchWordCount;
+
 
   public User(String name) {
     this.name = name;
     specialties = new HashSet<String>();
     userBio = "[user did not add a bio]";
+    savedMatchWordCount = new HashMap<String, Integer>();
   }
+
   public String getName() {
       return name;
   }
@@ -135,10 +141,33 @@ public final class User {
 
   public void setBio(String userBio) {
       this.userBio = userBio;
+
+      //update map that counts every user bio word in MatchRanking
+      if(userBio != null) {
+          MatchRanking.addToAllUserWordCount(userBio);
+      }
   }
 
   public String getBio() {
       return userBio;
   }
+
+  public void addNewBioToMapCount(String newBio) {
+        String[] bioWords = newBio.toLowerCase().split("\\W+");
+            
+        //add each word in bio to map
+        for(String word : bioWords) {
+            if(savedMatchWordCount.containsKey(word)) {
+                Integer oldCount = savedMatchWordCount.get(word);
+                savedMatchWordCount.put(word, oldCount + 1); 
+            } else {
+                savedMatchWordCount.put(word, 1);
+            }
+        }
+    }
+
+    public Map<String, Integer> getBioMap() {
+        return savedMatchWordCount;
+    }
 
 }

--- a/src/main/java/com/google/sps/servlets/MatchServlet.java
+++ b/src/main/java/com/google/sps/servlets/MatchServlet.java
@@ -67,6 +67,11 @@ public class MatchServlet extends HttpServlet {
         for (String matchName : matchesToSave) {
           User newMatch = new Gson().fromJson(matchName, User.class);
           matchRepository.addMatch(userToAdd, newMatch);
+
+          //add bio word count to current user
+        //   User currentUser = sessionContext.getLoggedInUser();
+        userToAdd.addNewBioToMapCount(newMatch.getBio());
+
         }
       } else {
         System.err.println("new-matches is null in MatchServlet doPost()");

--- a/src/main/java/com/google/sps/servlets/MatchServlet.java
+++ b/src/main/java/com/google/sps/servlets/MatchServlet.java
@@ -69,8 +69,7 @@ public class MatchServlet extends HttpServlet {
           matchRepository.addMatch(userToAdd, newMatch);
 
           //add bio word count to current user
-        //   User currentUser = sessionContext.getLoggedInUser();
-        userToAdd.addNewBioToMapCount(newMatch.getBio());
+          userToAdd.addNewBioToMapCount(newMatch.getBio());
 
         }
       } else {

--- a/src/main/java/com/google/sps/servlets/NewMatchQueryServlet.java
+++ b/src/main/java/com/google/sps/servlets/NewMatchQueryServlet.java
@@ -45,7 +45,7 @@ public class NewMatchQueryServlet extends HttpServlet {
 
     // Find the possible matches.
     MatchQuery matchQuery = new MatchQuery();
-    Collection<User> answer = matchQuery.query(matchRequest, userSavedMatches);
+    Collection<User> answer = matchQuery.query(sessionContext.getLoggedInUser().getBioMap(), matchRequest, userSavedMatches);
 
     // Convert the answer to JSON
     String jsonResponse = gson.toJson(answer);

--- a/src/main/java/com/google/sps/servlets/NewMatchQueryServlet.java
+++ b/src/main/java/com/google/sps/servlets/NewMatchQueryServlet.java
@@ -45,7 +45,7 @@ public class NewMatchQueryServlet extends HttpServlet {
 
     // Find the possible matches.
     MatchQuery matchQuery = new MatchQuery();
-    Collection<User> answer = matchQuery.query(sessionContext.getLoggedInUser().getBioMap(), matchRequest, userSavedMatches);
+    Collection<User> answer = matchQuery.query(sessionContext.getLoggedInUser(), matchRequest, userSavedMatches);
 
     // Convert the answer to JSON
     String jsonResponse = gson.toJson(answer);

--- a/src/test/java/com/google/sps/MatchQueryTest.java
+++ b/src/test/java/com/google/sps/MatchQueryTest.java
@@ -1,64 +1,65 @@
-// package com.google.sps;
+package com.google.sps;
 
-// import com.google.sps.algorithms.MatchQuery;
-// import com.google.sps.data.MatchRequest;
-// import com.google.sps.data.NonPersistentMatchRepository;
-// import com.google.sps.data.NonPersistentUserRepository;
-// import com.google.sps.data.User;
-// import com.google.sps.data.UserRepository;
-// import java.util.ArrayList;
-// import java.util.Collection;
-// import org.junit.Assert;
-// import org.junit.Before;
-// import org.junit.Test;
-// import org.junit.runner.RunWith;
-// import org.junit.runners.JUnit4;
-// /** */
-// @RunWith(JUnit4.class)
-// public final class MatchQueryTest {
+import com.google.sps.algorithms.MatchQuery;
+import com.google.sps.data.MatchRequest;
+import com.google.sps.data.NonPersistentMatchRepository;
+import com.google.sps.data.NonPersistentUserRepository;
+import com.google.sps.data.User;
+import com.google.sps.data.UserRepository;
+import java.util.ArrayList;
+import java.util.Collection;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-//   private static final MatchRequest EMPTY_REQUEST = new MatchRequest();
-//   private static final MatchRequest ML_REQUEST = new MatchRequest("Machine Learning");
-//   private static final MatchRequest BAD_REQUEST = new MatchRequest("not a specialty");
-//   private static final MatchQuery MATCH_QUERY = new MatchQuery();
+/** */
+@RunWith(JUnit4.class)
+public final class MatchQueryTest {
 
-//   private NonPersistentMatchRepository matchRepo;
-//   private UserRepository userRepository = new NonPersistentUserRepository();
-//   private User testUser;
-//   Collection<User> userSavedMatches;
+  private static final MatchRequest EMPTY_REQUEST = new MatchRequest();
+  private static final MatchRequest ML_REQUEST = new MatchRequest("Machine Learning");
+  private static final MatchRequest BAD_REQUEST = new MatchRequest("not a specialty");
+  private static final MatchQuery MATCH_QUERY = new MatchQuery();
 
-//   @Before
-//   public void setup() {
-//     userRepository.addFakeMentors();
-//     matchRepo = new NonPersistentMatchRepository();
-//     testUser = matchRepo.addTestData();
-//     userSavedMatches = matchRepo.getMatchesForUser(testUser.getId());
-//   }
+  private NonPersistentMatchRepository matchRepo;
+  private UserRepository userRepository = new NonPersistentUserRepository();
+  private User testUser;
+  Collection<User> userSavedMatches;
 
-//   @Test
-//   public void emptyRequest_shouldReturnNoMentors() {
-//     Assert.assertTrue(MATCH_QUERY.query(EMPTY_REQUEST, userSavedMatches, userRepository).isEmpty());
-//   }
+  @Before
+  public void setup() {
+    userRepository.addFakeMentors();
+    matchRepo = new NonPersistentMatchRepository();
+    testUser = matchRepo.addTestData();
+    userSavedMatches = matchRepo.getMatchesForUser(testUser.getId());
+  }
 
-//   @Test
-//   public void mlRequest_ShouldReturnMLMentors() {
-//     Assert.assertEquals(2, MATCH_QUERY.query(ML_REQUEST, userSavedMatches, userRepository).size());
-//   }
+  @Test
+  public void emptyRequest_shouldReturnNoMentors() {
+    Assert.assertTrue(MATCH_QUERY.query(testUser, EMPTY_REQUEST, userSavedMatches, userRepository).isEmpty());
+  }
 
-//   @Test
-//   public void badRequest_ShouldReturnNoMentors() {
-//     Assert.assertTrue(MATCH_QUERY.query(BAD_REQUEST, userSavedMatches, userRepository).isEmpty());
-//   }
+  @Test
+  public void mlRequest_ShouldReturnMLMentors() {
+    Assert.assertEquals(2, MATCH_QUERY.query(testUser, ML_REQUEST, userSavedMatches, userRepository).size());
+  }
 
-//   @Test
-//   public void noRepeatMatches() {
-//     // Save one of the mentors so that it should skip over and only return 1 new mentor
-//     User newMentor = new User("Andre Harder");
-//     newMentor.addSpecialty("Machine Learning");
-//     newMentor.setId("1");
-//     userSavedMatches.add(newMentor);
+  @Test
+  public void badRequest_ShouldReturnNoMentors() {
+    Assert.assertTrue(MATCH_QUERY.query(testUser, BAD_REQUEST, userSavedMatches, userRepository).isEmpty());
+  }
 
-//     Assert.assertEquals(1, MATCH_QUERY.query(ML_REQUEST, userSavedMatches, userRepository).size());
-//   }
+  @Test
+  public void noRepeatMatches() {
+    // Save one of the mentors so that it should skip over and only return 1 new mentor
+    User newMentor = new User("Andre Harder");
+    newMentor.addSpecialty("Machine Learning");
+    newMentor.setId("1");
+    userSavedMatches.add(newMentor);
 
-// }
+    Assert.assertEquals(1, MATCH_QUERY.query(testUser, ML_REQUEST, userSavedMatches, userRepository).size());
+  }
+
+}

--- a/src/test/java/com/google/sps/MatchQueryTest.java
+++ b/src/test/java/com/google/sps/MatchQueryTest.java
@@ -1,64 +1,64 @@
-package com.google.sps;
+// package com.google.sps;
 
-import com.google.sps.algorithms.MatchQuery;
-import com.google.sps.data.MatchRequest;
-import com.google.sps.data.NonPersistentMatchRepository;
-import com.google.sps.data.NonPersistentUserRepository;
-import com.google.sps.data.User;
-import com.google.sps.data.UserRepository;
-import java.util.ArrayList;
-import java.util.Collection;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-/** */
-@RunWith(JUnit4.class)
-public final class MatchQueryTest {
+// import com.google.sps.algorithms.MatchQuery;
+// import com.google.sps.data.MatchRequest;
+// import com.google.sps.data.NonPersistentMatchRepository;
+// import com.google.sps.data.NonPersistentUserRepository;
+// import com.google.sps.data.User;
+// import com.google.sps.data.UserRepository;
+// import java.util.ArrayList;
+// import java.util.Collection;
+// import org.junit.Assert;
+// import org.junit.Before;
+// import org.junit.Test;
+// import org.junit.runner.RunWith;
+// import org.junit.runners.JUnit4;
+// /** */
+// @RunWith(JUnit4.class)
+// public final class MatchQueryTest {
 
-  private static final MatchRequest EMPTY_REQUEST = new MatchRequest();
-  private static final MatchRequest ML_REQUEST = new MatchRequest("Machine Learning");
-  private static final MatchRequest BAD_REQUEST = new MatchRequest("not a specialty");
-  private static final MatchQuery MATCH_QUERY = new MatchQuery();
+//   private static final MatchRequest EMPTY_REQUEST = new MatchRequest();
+//   private static final MatchRequest ML_REQUEST = new MatchRequest("Machine Learning");
+//   private static final MatchRequest BAD_REQUEST = new MatchRequest("not a specialty");
+//   private static final MatchQuery MATCH_QUERY = new MatchQuery();
 
-  private NonPersistentMatchRepository matchRepo;
-  private UserRepository userRepository = new NonPersistentUserRepository();
-  private User testUser;
-  Collection<User> userSavedMatches;
+//   private NonPersistentMatchRepository matchRepo;
+//   private UserRepository userRepository = new NonPersistentUserRepository();
+//   private User testUser;
+//   Collection<User> userSavedMatches;
 
-  @Before
-  public void setup() {
-    userRepository.addFakeMentors();
-    matchRepo = new NonPersistentMatchRepository();
-    testUser = matchRepo.addTestData();
-    userSavedMatches = matchRepo.getMatchesForUser(testUser.getId());
-  }
+//   @Before
+//   public void setup() {
+//     userRepository.addFakeMentors();
+//     matchRepo = new NonPersistentMatchRepository();
+//     testUser = matchRepo.addTestData();
+//     userSavedMatches = matchRepo.getMatchesForUser(testUser.getId());
+//   }
 
-  @Test
-  public void emptyRequest_shouldReturnNoMentors() {
-    Assert.assertTrue(MATCH_QUERY.query(EMPTY_REQUEST, userSavedMatches, userRepository).isEmpty());
-  }
+//   @Test
+//   public void emptyRequest_shouldReturnNoMentors() {
+//     Assert.assertTrue(MATCH_QUERY.query(EMPTY_REQUEST, userSavedMatches, userRepository).isEmpty());
+//   }
 
-  @Test
-  public void mlRequest_ShouldReturnMLMentors() {
-    Assert.assertEquals(2, MATCH_QUERY.query(ML_REQUEST, userSavedMatches, userRepository).size());
-  }
+//   @Test
+//   public void mlRequest_ShouldReturnMLMentors() {
+//     Assert.assertEquals(2, MATCH_QUERY.query(ML_REQUEST, userSavedMatches, userRepository).size());
+//   }
 
-  @Test
-  public void badRequest_ShouldReturnNoMentors() {
-    Assert.assertTrue(MATCH_QUERY.query(BAD_REQUEST, userSavedMatches, userRepository).isEmpty());
-  }
+//   @Test
+//   public void badRequest_ShouldReturnNoMentors() {
+//     Assert.assertTrue(MATCH_QUERY.query(BAD_REQUEST, userSavedMatches, userRepository).isEmpty());
+//   }
 
-  @Test
-  public void noRepeatMatches() {
-    // Save one of the mentors so that it should skip over and only return 1 new mentor
-    User newMentor = new User("Andre Harder");
-    newMentor.addSpecialty("Machine Learning");
-    newMentor.setId("1");
-    userSavedMatches.add(newMentor);
+//   @Test
+//   public void noRepeatMatches() {
+//     // Save one of the mentors so that it should skip over and only return 1 new mentor
+//     User newMentor = new User("Andre Harder");
+//     newMentor.addSpecialty("Machine Learning");
+//     newMentor.setId("1");
+//     userSavedMatches.add(newMentor);
 
-    Assert.assertEquals(1, MATCH_QUERY.query(ML_REQUEST, userSavedMatches, userRepository).size());
-  }
+//     Assert.assertEquals(1, MATCH_QUERY.query(ML_REQUEST, userSavedMatches, userRepository).size());
+//   }
 
-}
+// }

--- a/src/test/java/com/google/sps/MatchRankingTest.java
+++ b/src/test/java/com/google/sps/MatchRankingTest.java
@@ -33,7 +33,7 @@ public final class MatchRankingTest {
   private User user_forward = new User("");
   private User user_forward_repeat = new User("");
   private User user_backward = new User("");
-  private Collection<User> allUsers;
+//   private Collection<User> allUsers;
 
   @Before
   public void setup() {
@@ -79,31 +79,44 @@ public final class MatchRankingTest {
     user_backward.setBio("life is security");
     user_backward.setId("15y");
 
-    allUsers = new ArrayList<User>();
-    allUsers.add(user_a);
-    allUsers.add(user_a_doubled);
-    allUsers.add(user_b);
-    allUsers.add(user_c);
-    allUsers.add(user_d);
-    allUsers.add(user_e);
-    allUsers.add(user_long);
-    allUsers.add(user_long_security);
-    allUsers.add(user_short);
-    allUsers.add(user_empty);
-    allUsers.add(user_spanish);
-    allUsers.add(user_bad_format);
-    allUsers.add(user_numbers);
-    allUsers.add(user_forward);
-    allUsers.add(user_forward_repeat);
-    allUsers.add(user_backward);
+    // allUsers = new ArrayList<User>();
+    // allUsers.add(user_a);
+    // allUsers.add(user_a_doubled);
+    // allUsers.add(user_b);
+    // allUsers.add(user_c);
+    // allUsers.add(user_d);
+    // allUsers.add(user_e);
+    // allUsers.add(user_long);
+    // allUsers.add(user_long_security);
+    // allUsers.add(user_short);
+    // allUsers.add(user_empty);
+    // allUsers.add(user_spanish);
+    // allUsers.add(user_bad_format);
+    // allUsers.add(user_numbers);
+    // allUsers.add(user_forward);
+    // allUsers.add(user_forward_repeat);
+    // allUsers.add(user_backward);
+
+    // MatchRanking.addToAllUserWordCount(user_a.getBio());
+    // MatchRanking.addToAllUserWordCount(user_a_doubled.getBio());
+    // MatchRanking.addToAllUserWordCount(user_b.getBio());
+    // MatchRanking.addToAllUserWordCount(user_c.getBio());
+    // MatchRanking.addToAllUserWordCount(user_d.getBio());
+    // MatchRanking.addToAllUserWordCount(user_e.getBio());
+    // MatchRanking.addToAllUserWordCount(user_long.getBio());
+    // MatchRanking.addToAllUserWordCount(user_long_security.getBio());
   }
 
   //User A should have a higher score than User B because both D and E have "security" in them
   @Test
   public void basicRanking() {
-      Collection<User> savedMatches = new HashSet<User>();
-      savedMatches.add(user_d);
-      savedMatches.add(user_e);
+    //   Collection<User> savedMatches = new HashSet<User>();
+    //   savedMatches.add(user_d);
+    //   savedMatches.add(user_e);
+
+    User currentUser = new User("");
+    currentUser.addNewBioToMapCount(user_d.getBio());
+    currentUser.addNewBioToMapCount(user_e.getBio());
 
       Collection<User> newMatches = new HashSet<User>();
       newMatches.add(user_a);
@@ -113,17 +126,22 @@ public final class MatchRankingTest {
       expected.add(user_a);
       expected.add(user_b);
 
-      List<User> result = MatchRanking.rankMatches(savedMatches, allUsers, newMatches);
+      List<User> result = MatchRanking.rankMatches(currentUser.getBioMap(), newMatches);
       Assert.assertEquals(expected, result);
   }
 
   //the long bio user should have a lower score because it has no words in common with the saved users
   @Test
   public void longBioTest() {
-      Collection<User> savedMatches = new HashSet<User>();
-      savedMatches.add(user_a);
-      savedMatches.add(user_b);
-      savedMatches.add(user_d);
+    //   Collection<User> savedMatches = new HashSet<User>();
+    //   savedMatches.add(user_a);
+    //   savedMatches.add(user_b);
+    //   savedMatches.add(user_d);
+
+    User currentUser = new User("");
+    currentUser.addNewBioToMapCount(user_a.getBio());
+    currentUser.addNewBioToMapCount(user_b.getBio());
+    currentUser.addNewBioToMapCount(user_d.getBio());
 
       Collection<User> newMatches = new HashSet<User>();
       newMatches.add(user_long);
@@ -133,203 +151,203 @@ public final class MatchRankingTest {
       expected.add(user_e);
       expected.add(user_long);
 
-      List<User> result = MatchRanking.rankMatches(savedMatches, allUsers, newMatches);
+      List<User> result = MatchRanking.rankMatches(currentUser.getBioMap(), newMatches);
       Assert.assertEquals(expected, result);
   }
   
-  //the user with bad formatting should have a lower score because it has nothing in common with the saved users
-  @Test
-  public void badBioTest() {
-      Collection<User> savedMatches = new HashSet<User>();
-      savedMatches.add(user_a);
-      savedMatches.add(user_b);
-      savedMatches.add(user_d);
+//   //the user with bad formatting should have a lower score because it has nothing in common with the saved users
+//   @Test
+//   public void badBioTest() {
+//       Collection<User> savedMatches = new HashSet<User>();
+//       savedMatches.add(user_a);
+//       savedMatches.add(user_b);
+//       savedMatches.add(user_d);
 
-      Collection<User> newMatches = new HashSet<User>();
-      newMatches.add(user_bad_format);
-      newMatches.add(user_e);
+//       Collection<User> newMatches = new HashSet<User>();
+//       newMatches.add(user_bad_format);
+//       newMatches.add(user_e);
 
-      List<User> expected = new ArrayList<User>();
-      expected.add(user_e);
-      expected.add(user_bad_format);
+//       List<User> expected = new ArrayList<User>();
+//       expected.add(user_e);
+//       expected.add(user_bad_format);
 
-      List<User> result = MatchRanking.rankMatches(savedMatches, allUsers, newMatches);
-      Assert.assertEquals(expected, result);
-  }
+//       List<User> result = MatchRanking.rankMatches(savedMatches, newMatches);
+//       Assert.assertEquals(expected, result);
+//   }
 
-  //the user in spanish should have a lower score because it has nothing in common with saved users
-  @Test
-  public void wrongLanguageTest() {
-      Collection<User> savedMatches = new HashSet<User>();
-      savedMatches.add(user_a);
-      savedMatches.add(user_b);
-      savedMatches.add(user_d);
+//   //the user in spanish should have a lower score because it has nothing in common with saved users
+//   @Test
+//   public void wrongLanguageTest() {
+//       Collection<User> savedMatches = new HashSet<User>();
+//       savedMatches.add(user_a);
+//       savedMatches.add(user_b);
+//       savedMatches.add(user_d);
 
-      Collection<User> newMatches = new HashSet<User>();
-      newMatches.add(user_spanish);
-      newMatches.add(user_e);
+//       Collection<User> newMatches = new HashSet<User>();
+//       newMatches.add(user_spanish);
+//       newMatches.add(user_e);
 
-      List<User> expected = new ArrayList<User>();
-      expected.add(user_e);
-      expected.add(user_spanish);
+//       List<User> expected = new ArrayList<User>();
+//       expected.add(user_e);
+//       expected.add(user_spanish);
 
-      List<User> result = MatchRanking.rankMatches(savedMatches, allUsers, newMatches);
-      Assert.assertEquals(expected, result);
-  }
+//       List<User> result = MatchRanking.rankMatches(savedMatches, newMatches);
+//       Assert.assertEquals(expected, result);
+//   }
 
-  //the user with no words matched should have a lower score because it has nothing in common with saved users
-  @Test
-  public void shortBioTest() {
-      Collection<User> savedMatches = new HashSet<User>();
-      savedMatches.add(user_a);
-      savedMatches.add(user_b);
-      savedMatches.add(user_d);
+//   //the user with no words matched should have a lower score because it has nothing in common with saved users
+//   @Test
+//   public void shortBioTest() {
+//       Collection<User> savedMatches = new HashSet<User>();
+//       savedMatches.add(user_a);
+//       savedMatches.add(user_b);
+//       savedMatches.add(user_d);
 
-      Collection<User> newMatches = new HashSet<User>();
-      newMatches.add(user_short);
-      newMatches.add(user_e);
+//       Collection<User> newMatches = new HashSet<User>();
+//       newMatches.add(user_short);
+//       newMatches.add(user_e);
 
-      List<User> expected = new ArrayList<User>();
-      expected.add(user_e);
-      expected.add(user_short);
+//       List<User> expected = new ArrayList<User>();
+//       expected.add(user_e);
+//       expected.add(user_short);
 
-      List<User> result = MatchRanking.rankMatches(savedMatches, allUsers, newMatches);
-      Assert.assertEquals(expected, result);
-  }
+//       List<User> result = MatchRanking.rankMatches(savedMatches, newMatches);
+//       Assert.assertEquals(expected, result);
+//   }
 
-  //two users that are the same should only be returned once
-  @Test
-  public void duplicateUserTest() {
-      Collection<User> savedMatches = new HashSet<User>();
-      savedMatches.add(user_a);
-      savedMatches.add(user_b);
-      savedMatches.add(user_d);
+//   //two users that are the same should only be returned once
+//   @Test
+//   public void duplicateUserTest() {
+//       Collection<User> savedMatches = new HashSet<User>();
+//       savedMatches.add(user_a);
+//       savedMatches.add(user_b);
+//       savedMatches.add(user_d);
 
-      Collection<User> newMatches = new HashSet<User>();
-      newMatches.add(user_e);
-      newMatches.add(user_e);
+//       Collection<User> newMatches = new HashSet<User>();
+//       newMatches.add(user_e);
+//       newMatches.add(user_e);
 
-      List<User> expected = new ArrayList<User>();
-      expected.add(user_e);
+//       List<User> expected = new ArrayList<User>();
+//       expected.add(user_e);
 
-      List<User> result = MatchRanking.rankMatches(savedMatches, allUsers, newMatches);
-      Assert.assertEquals(expected, result);
-  }
+//       List<User> result = MatchRanking.rankMatches(savedMatches, newMatches);
+//       Assert.assertEquals(expected, result);
+//   }
 
-  //the empty user should be ranked last because it should have a score of 0
-  @Test
-  public void emptyBioTest() {
-      Collection<User> savedMatches = new HashSet<User>();
-      savedMatches.add(user_a);
-      savedMatches.add(user_b);
-      savedMatches.add(user_d);
+//   //the empty user should be ranked last because it should have a score of 0
+//   @Test
+//   public void emptyBioTest() {
+//       Collection<User> savedMatches = new HashSet<User>();
+//       savedMatches.add(user_a);
+//       savedMatches.add(user_b);
+//       savedMatches.add(user_d);
 
-      Collection<User> newMatches = new HashSet<User>();
-      newMatches.add(user_e);
-      newMatches.add(user_empty);
+//       Collection<User> newMatches = new HashSet<User>();
+//       newMatches.add(user_e);
+//       newMatches.add(user_empty);
 
-      List<User> expected = new ArrayList<User>();
-      expected.add(user_e);
-      expected.add(user_empty);
+//       List<User> expected = new ArrayList<User>();
+//       expected.add(user_e);
+//       expected.add(user_empty);
 
-      List<User> result = MatchRanking.rankMatches(savedMatches, allUsers, newMatches);
-      Assert.assertEquals(expected, result);
-  }
+//       List<User> result = MatchRanking.rankMatches(savedMatches, newMatches);
+//       Assert.assertEquals(expected, result);
+//   }
 
-  //the user with only numbers should be last because it has nothing in common with the saved users
-  @Test
-  public void numberBioTest() {
-      Collection<User> savedMatches = new HashSet<User>();
-      savedMatches.add(user_a);
-      savedMatches.add(user_b);
-      savedMatches.add(user_d);
+//   //the user with only numbers should be last because it has nothing in common with the saved users
+//   @Test
+//   public void numberBioTest() {
+//       Collection<User> savedMatches = new HashSet<User>();
+//       savedMatches.add(user_a);
+//       savedMatches.add(user_b);
+//       savedMatches.add(user_d);
 
-      Collection<User> newMatches = new HashSet<User>();
-      newMatches.add(user_e);
-      newMatches.add(user_numbers);
+//       Collection<User> newMatches = new HashSet<User>();
+//       newMatches.add(user_e);
+//       newMatches.add(user_numbers);
 
-      List<User> expected = new ArrayList<User>();
-      expected.add(user_e);
-      expected.add(user_numbers);
+//       List<User> expected = new ArrayList<User>();
+//       expected.add(user_e);
+//       expected.add(user_numbers);
 
-      List<User> result = MatchRanking.rankMatches(savedMatches, allUsers, newMatches);
-      Assert.assertEquals(expected, result);
-  }
+//       List<User> result = MatchRanking.rankMatches(savedMatches, newMatches);
+//       Assert.assertEquals(expected, result);
+//   }
 
-  //two users with the same words in their bios should have the same scores
-  @Test
-  public void sameWordsInBiosTest() {
-      Collection<User> savedMatches = new HashSet<User>();
-      savedMatches.add(user_a);
-      savedMatches.add(user_b);
-      savedMatches.add(user_d);
+//   //two users with the same words in their bios should have the same scores
+//   @Test
+//   public void sameWordsInBiosTest() {
+//       Collection<User> savedMatches = new HashSet<User>();
+//       savedMatches.add(user_a);
+//       savedMatches.add(user_b);
+//       savedMatches.add(user_d);
 
-      Collection<User> newMatches = new HashSet<User>();
-      newMatches.add(user_forward);
-      newMatches.add(user_backward);
+//       Collection<User> newMatches = new HashSet<User>();
+//       newMatches.add(user_forward);
+//       newMatches.add(user_backward);
 
-      Map<User, Double> matchScores = MatchRanking.getMatchScores(savedMatches, allUsers, newMatches);
+//       Map<User, Double> matchScores = MatchRanking.getMatchScores(savedMatches, newMatches);
       
-      Assert.assertTrue(compareDoubles(matchScores.get(user_forward), matchScores.get(user_backward)));
-  }
+//       Assert.assertTrue(compareDoubles(matchScores.get(user_forward), matchScores.get(user_backward)));
+//   }
 
-  //two users with equal bios should have the same scores
-  @Test
-  public void equalBiosTest() {
-      Collection<User> savedMatches = new HashSet<User>();
-      savedMatches.add(user_a);
-      savedMatches.add(user_b);
-      savedMatches.add(user_d);
+//   //two users with equal bios should have the same scores
+//   @Test
+//   public void equalBiosTest() {
+//       Collection<User> savedMatches = new HashSet<User>();
+//       savedMatches.add(user_a);
+//       savedMatches.add(user_b);
+//       savedMatches.add(user_d);
 
-      Collection<User> newMatches = new HashSet<User>();
-      newMatches.add(user_forward);
-      newMatches.add(user_forward_repeat);
+//       Collection<User> newMatches = new HashSet<User>();
+//       newMatches.add(user_forward);
+//       newMatches.add(user_forward_repeat);
 
-      Map<User, Double> matchScores = MatchRanking.getMatchScores(savedMatches, allUsers, newMatches);
+//       Map<User, Double> matchScores = MatchRanking.getMatchScores(savedMatches, newMatches);
       
-      Assert.assertTrue(compareDoubles(matchScores.get(user_forward), matchScores.get(user_forward_repeat)));
-  }
+//       Assert.assertTrue(compareDoubles(matchScores.get(user_forward), matchScores.get(user_forward_repeat)));
+//   }
 
-  //a long user bio that has the word "security" a lot should be ranked higher than the user with "security" once
-  @Test
-  public void longBioWithKeywordTest() {
-      Collection<User> savedMatches = new HashSet<User>();
-      savedMatches.add(user_d);
-      savedMatches.add(user_e);
-      savedMatches.add(user_forward);
-      savedMatches.add(user_backward);
+//   //a long user bio that has the word "security" a lot should be ranked higher than the user with "security" once
+//   @Test
+//   public void longBioWithKeywordTest() {
+//       Collection<User> savedMatches = new HashSet<User>();
+//       savedMatches.add(user_d);
+//       savedMatches.add(user_e);
+//       savedMatches.add(user_forward);
+//       savedMatches.add(user_backward);
 
-      Collection<User> newMatches = new HashSet<User>();
-      newMatches.add(user_a);
-      newMatches.add(user_long_security);
+//       Collection<User> newMatches = new HashSet<User>();
+//       newMatches.add(user_a);
+//       newMatches.add(user_long_security);
 
-      List<User> expected = new ArrayList<User>();
-      expected.add(user_long_security);
-      expected.add(user_a);
+//       List<User> expected = new ArrayList<User>();
+//       expected.add(user_long_security);
+//       expected.add(user_a);
 
-      List<User> result = MatchRanking.rankMatches(savedMatches, allUsers, newMatches);
-      Assert.assertEquals(expected, result);
-  }
+//       List<User> result = MatchRanking.rankMatches(savedMatches, newMatches);
+//       Assert.assertEquals(expected, result);
+//   }
 
-  //compares two users with the same words, but one with two of every word and makes sure that they have the same score
-  @Test
-  public void nthRootTest() {
-      Collection<User> savedMatches = new HashSet<User>();
-      savedMatches.add(user_d);
-      savedMatches.add(user_e);
+//   //compares two users with the same words, but one with two of every word and makes sure that they have the same score
+//   @Test
+//   public void nthRootTest() {
+//       Collection<User> savedMatches = new HashSet<User>();
+//       savedMatches.add(user_d);
+//       savedMatches.add(user_e);
 
-      Collection<User> newMatches = new HashSet<User>();
-      newMatches.add(user_a);
-      newMatches.add(user_a_doubled);
+//       Collection<User> newMatches = new HashSet<User>();
+//       newMatches.add(user_a);
+//       newMatches.add(user_a_doubled);
 
-      Map<User, Double> matchScores = MatchRanking.getMatchScores(savedMatches, allUsers, newMatches);
+//       Map<User, Double> matchScores = MatchRanking.getMatchScores(savedMatches, newMatches);
 
-      Assert.assertTrue(compareDoubles(matchScores.get(user_a), matchScores.get(user_a_doubled)));
-  }
+//       Assert.assertTrue(compareDoubles(matchScores.get(user_a), matchScores.get(user_a_doubled)));
+//   }
 
-  //helper method to compare doubles used in some tests
-  private static boolean compareDoubles(double d1, double d2) {
-    return (Math.abs(d1 - d2) < 0.0001);
-  }
+//   //helper method to compare doubles used in some tests
+//   private static boolean compareDoubles(double d1, double d2) {
+//     return (Math.abs(d1 - d2) < 0.0001);
+//   }
 
 }

--- a/src/test/java/com/google/sps/MatchRankingTest.java
+++ b/src/test/java/com/google/sps/MatchRankingTest.java
@@ -33,7 +33,6 @@ public final class MatchRankingTest {
   private User user_forward = new User("");
   private User user_forward_repeat = new User("");
   private User user_backward = new User("");
-//   private Collection<User> allUsers;
 
   @Before
   public void setup() {
@@ -78,276 +77,240 @@ public final class MatchRankingTest {
     user_forward_repeat.setId("57792");
     user_backward.setBio("life is security");
     user_backward.setId("15y");
-
-    // allUsers = new ArrayList<User>();
-    // allUsers.add(user_a);
-    // allUsers.add(user_a_doubled);
-    // allUsers.add(user_b);
-    // allUsers.add(user_c);
-    // allUsers.add(user_d);
-    // allUsers.add(user_e);
-    // allUsers.add(user_long);
-    // allUsers.add(user_long_security);
-    // allUsers.add(user_short);
-    // allUsers.add(user_empty);
-    // allUsers.add(user_spanish);
-    // allUsers.add(user_bad_format);
-    // allUsers.add(user_numbers);
-    // allUsers.add(user_forward);
-    // allUsers.add(user_forward_repeat);
-    // allUsers.add(user_backward);
-
-    // MatchRanking.addToAllUserWordCount(user_a.getBio());
-    // MatchRanking.addToAllUserWordCount(user_a_doubled.getBio());
-    // MatchRanking.addToAllUserWordCount(user_b.getBio());
-    // MatchRanking.addToAllUserWordCount(user_c.getBio());
-    // MatchRanking.addToAllUserWordCount(user_d.getBio());
-    // MatchRanking.addToAllUserWordCount(user_e.getBio());
-    // MatchRanking.addToAllUserWordCount(user_long.getBio());
-    // MatchRanking.addToAllUserWordCount(user_long_security.getBio());
   }
 
   //User A should have a higher score than User B because both D and E have "security" in them
   @Test
   public void basicRanking() {
-    //   Collection<User> savedMatches = new HashSet<User>();
-    //   savedMatches.add(user_d);
-    //   savedMatches.add(user_e);
-
     User currentUser = new User("");
     currentUser.addNewBioToMapCount(user_d.getBio());
     currentUser.addNewBioToMapCount(user_e.getBio());
 
-      Collection<User> newMatches = new HashSet<User>();
-      newMatches.add(user_a);
-      newMatches.add(user_b);
+    Collection<User> newMatches = new HashSet<User>();
+    newMatches.add(user_a);
+    newMatches.add(user_b);
 
-      List<User> expected = new ArrayList<User>();
-      expected.add(user_a);
-      expected.add(user_b);
+    List<User> expected = new ArrayList<User>();
+    expected.add(user_a);
+    expected.add(user_b);
 
-      List<User> result = MatchRanking.rankMatches(currentUser.getBioMap(), newMatches);
-      Assert.assertEquals(expected, result);
+    List<User> result = MatchRanking.rankMatches(currentUser.getBioMap(), newMatches);
+    Assert.assertEquals(expected, result);
   }
 
   //the long bio user should have a lower score because it has no words in common with the saved users
   @Test
   public void longBioTest() {
-    //   Collection<User> savedMatches = new HashSet<User>();
-    //   savedMatches.add(user_a);
-    //   savedMatches.add(user_b);
-    //   savedMatches.add(user_d);
-
     User currentUser = new User("");
     currentUser.addNewBioToMapCount(user_a.getBio());
     currentUser.addNewBioToMapCount(user_b.getBio());
     currentUser.addNewBioToMapCount(user_d.getBio());
 
-      Collection<User> newMatches = new HashSet<User>();
-      newMatches.add(user_long);
-      newMatches.add(user_e);
+    Collection<User> newMatches = new HashSet<User>();
+    newMatches.add(user_long);
+    newMatches.add(user_e);
 
-      List<User> expected = new ArrayList<User>();
-      expected.add(user_e);
-      expected.add(user_long);
+    List<User> expected = new ArrayList<User>();
+    expected.add(user_e);
+    expected.add(user_long);
 
-      List<User> result = MatchRanking.rankMatches(currentUser.getBioMap(), newMatches);
-      Assert.assertEquals(expected, result);
+    List<User> result = MatchRanking.rankMatches(currentUser.getBioMap(), newMatches);
+    Assert.assertEquals(expected, result);
   }
   
-//   //the user with bad formatting should have a lower score because it has nothing in common with the saved users
-//   @Test
-//   public void badBioTest() {
-//       Collection<User> savedMatches = new HashSet<User>();
-//       savedMatches.add(user_a);
-//       savedMatches.add(user_b);
-//       savedMatches.add(user_d);
+  //the user with bad formatting should have a lower score because it has nothing in common with the saved users
+  @Test
+  public void badBioTest() {
+    User currentUser = new User("");
+    currentUser.addNewBioToMapCount(user_a.getBio());
+    currentUser.addNewBioToMapCount(user_b.getBio());
+    currentUser.addNewBioToMapCount(user_d.getBio());
 
-//       Collection<User> newMatches = new HashSet<User>();
-//       newMatches.add(user_bad_format);
-//       newMatches.add(user_e);
+    Collection<User> newMatches = new HashSet<User>();
+    newMatches.add(user_bad_format);
+    newMatches.add(user_e);
 
-//       List<User> expected = new ArrayList<User>();
-//       expected.add(user_e);
-//       expected.add(user_bad_format);
+    List<User> expected = new ArrayList<User>();
+    expected.add(user_e);
+    expected.add(user_bad_format);
 
-//       List<User> result = MatchRanking.rankMatches(savedMatches, newMatches);
-//       Assert.assertEquals(expected, result);
-//   }
+    List<User> result = MatchRanking.rankMatches(currentUser.getBioMap(), newMatches);
+    Assert.assertEquals(expected, result);
+  }
 
-//   //the user in spanish should have a lower score because it has nothing in common with saved users
-//   @Test
-//   public void wrongLanguageTest() {
-//       Collection<User> savedMatches = new HashSet<User>();
-//       savedMatches.add(user_a);
-//       savedMatches.add(user_b);
-//       savedMatches.add(user_d);
+  //the user in spanish should have a lower score because it has nothing in common with saved users
+  @Test
+  public void wrongLanguageTest() {
+    User currentUser = new User("");
+    currentUser.addNewBioToMapCount(user_a.getBio());
+    currentUser.addNewBioToMapCount(user_b.getBio());
+    currentUser.addNewBioToMapCount(user_d.getBio());
 
-//       Collection<User> newMatches = new HashSet<User>();
-//       newMatches.add(user_spanish);
-//       newMatches.add(user_e);
+    Collection<User> newMatches = new HashSet<User>();
+    newMatches.add(user_spanish);
+    newMatches.add(user_e);
 
-//       List<User> expected = new ArrayList<User>();
-//       expected.add(user_e);
-//       expected.add(user_spanish);
+    List<User> expected = new ArrayList<User>();
+    expected.add(user_e);
+    expected.add(user_spanish);
 
-//       List<User> result = MatchRanking.rankMatches(savedMatches, newMatches);
-//       Assert.assertEquals(expected, result);
-//   }
+    List<User> result = MatchRanking.rankMatches(currentUser.getBioMap(), newMatches);
+    Assert.assertEquals(expected, result);
+  }
 
-//   //the user with no words matched should have a lower score because it has nothing in common with saved users
-//   @Test
-//   public void shortBioTest() {
-//       Collection<User> savedMatches = new HashSet<User>();
-//       savedMatches.add(user_a);
-//       savedMatches.add(user_b);
-//       savedMatches.add(user_d);
+  //the user with no words matched should have a lower score because it has nothing in common with saved users
+  @Test
+  public void shortBioTest() {
+    User currentUser = new User("");
+    currentUser.addNewBioToMapCount(user_a.getBio());
+    currentUser.addNewBioToMapCount(user_b.getBio());
+    currentUser.addNewBioToMapCount(user_d.getBio());
 
-//       Collection<User> newMatches = new HashSet<User>();
-//       newMatches.add(user_short);
-//       newMatches.add(user_e);
+    Collection<User> newMatches = new HashSet<User>();
+    newMatches.add(user_short);
+    newMatches.add(user_e);
 
-//       List<User> expected = new ArrayList<User>();
-//       expected.add(user_e);
-//       expected.add(user_short);
+    List<User> expected = new ArrayList<User>();
+    expected.add(user_e);
+    expected.add(user_short);
 
-//       List<User> result = MatchRanking.rankMatches(savedMatches, newMatches);
-//       Assert.assertEquals(expected, result);
-//   }
+    List<User> result = MatchRanking.rankMatches(currentUser.getBioMap(), newMatches);
+    Assert.assertEquals(expected, result);
+  }
 
-//   //two users that are the same should only be returned once
-//   @Test
-//   public void duplicateUserTest() {
-//       Collection<User> savedMatches = new HashSet<User>();
-//       savedMatches.add(user_a);
-//       savedMatches.add(user_b);
-//       savedMatches.add(user_d);
+  //two users that are the same should only be returned once
+  @Test
+  public void duplicateUserTest() {
+    User currentUser = new User("");
+    currentUser.addNewBioToMapCount(user_a.getBio());
+    currentUser.addNewBioToMapCount(user_b.getBio());
+    currentUser.addNewBioToMapCount(user_d.getBio());
 
-//       Collection<User> newMatches = new HashSet<User>();
-//       newMatches.add(user_e);
-//       newMatches.add(user_e);
+    Collection<User> newMatches = new HashSet<User>();
+    newMatches.add(user_e);
+    newMatches.add(user_e);
 
-//       List<User> expected = new ArrayList<User>();
-//       expected.add(user_e);
+    List<User> expected = new ArrayList<User>();
+    expected.add(user_e);
 
-//       List<User> result = MatchRanking.rankMatches(savedMatches, newMatches);
-//       Assert.assertEquals(expected, result);
-//   }
+    List<User> result = MatchRanking.rankMatches(currentUser.getBioMap(), newMatches);
+    Assert.assertEquals(expected, result);
+  }
 
-//   //the empty user should be ranked last because it should have a score of 0
-//   @Test
-//   public void emptyBioTest() {
-//       Collection<User> savedMatches = new HashSet<User>();
-//       savedMatches.add(user_a);
-//       savedMatches.add(user_b);
-//       savedMatches.add(user_d);
+  //the empty user should be ranked last because it should have a score of 0
+  @Test
+  public void emptyBioTest() {
+    User currentUser = new User("");
+    currentUser.addNewBioToMapCount(user_a.getBio());
+    currentUser.addNewBioToMapCount(user_b.getBio());
+    currentUser.addNewBioToMapCount(user_d.getBio());
 
-//       Collection<User> newMatches = new HashSet<User>();
-//       newMatches.add(user_e);
-//       newMatches.add(user_empty);
+    Collection<User> newMatches = new HashSet<User>();
+    newMatches.add(user_e);
+    newMatches.add(user_empty);
 
-//       List<User> expected = new ArrayList<User>();
-//       expected.add(user_e);
-//       expected.add(user_empty);
+    List<User> expected = new ArrayList<User>();
+    expected.add(user_e);
+    expected.add(user_empty);
 
-//       List<User> result = MatchRanking.rankMatches(savedMatches, newMatches);
-//       Assert.assertEquals(expected, result);
-//   }
+    List<User> result = MatchRanking.rankMatches(currentUser.getBioMap(), newMatches);
+    Assert.assertEquals(expected, result);
+  }
 
-//   //the user with only numbers should be last because it has nothing in common with the saved users
-//   @Test
-//   public void numberBioTest() {
-//       Collection<User> savedMatches = new HashSet<User>();
-//       savedMatches.add(user_a);
-//       savedMatches.add(user_b);
-//       savedMatches.add(user_d);
+  //the user with only numbers should be last because it has nothing in common with the saved users
+  @Test
+  public void numberBioTest() {
+    User currentUser = new User("");
+    currentUser.addNewBioToMapCount(user_a.getBio());
+    currentUser.addNewBioToMapCount(user_b.getBio());
+    currentUser.addNewBioToMapCount(user_d.getBio());
 
-//       Collection<User> newMatches = new HashSet<User>();
-//       newMatches.add(user_e);
-//       newMatches.add(user_numbers);
+    Collection<User> newMatches = new HashSet<User>();
+    newMatches.add(user_e);
+    newMatches.add(user_numbers);
 
-//       List<User> expected = new ArrayList<User>();
-//       expected.add(user_e);
-//       expected.add(user_numbers);
+    List<User> expected = new ArrayList<User>();
+    expected.add(user_e);
+    expected.add(user_numbers);
 
-//       List<User> result = MatchRanking.rankMatches(savedMatches, newMatches);
-//       Assert.assertEquals(expected, result);
-//   }
+    List<User> result = MatchRanking.rankMatches(currentUser.getBioMap(), newMatches);
+    Assert.assertEquals(expected, result);
+  }
 
-//   //two users with the same words in their bios should have the same scores
-//   @Test
-//   public void sameWordsInBiosTest() {
-//       Collection<User> savedMatches = new HashSet<User>();
-//       savedMatches.add(user_a);
-//       savedMatches.add(user_b);
-//       savedMatches.add(user_d);
+  //two users with the same words in their bios should have the same scores
+  @Test
+  public void sameWordsInBiosTest() {
+    User currentUser = new User("");
+    currentUser.addNewBioToMapCount(user_a.getBio());
+    currentUser.addNewBioToMapCount(user_b.getBio());
+    currentUser.addNewBioToMapCount(user_d.getBio());
 
-//       Collection<User> newMatches = new HashSet<User>();
-//       newMatches.add(user_forward);
-//       newMatches.add(user_backward);
+    Collection<User> newMatches = new HashSet<User>();
+    newMatches.add(user_forward);
+    newMatches.add(user_backward);
 
-//       Map<User, Double> matchScores = MatchRanking.getMatchScores(savedMatches, newMatches);
+    Map<User, Double> matchScores = MatchRanking.getMatchScores(currentUser.getBioMap(), newMatches);
       
-//       Assert.assertTrue(compareDoubles(matchScores.get(user_forward), matchScores.get(user_backward)));
-//   }
+    Assert.assertTrue(compareDoubles(matchScores.get(user_forward), matchScores.get(user_backward)));
+  }
 
-//   //two users with equal bios should have the same scores
-//   @Test
-//   public void equalBiosTest() {
-//       Collection<User> savedMatches = new HashSet<User>();
-//       savedMatches.add(user_a);
-//       savedMatches.add(user_b);
-//       savedMatches.add(user_d);
+  //two users with equal bios should have the same scores
+  @Test
+  public void equalBiosTest() {
+    User currentUser = new User("");
+    currentUser.addNewBioToMapCount(user_a.getBio());
+    currentUser.addNewBioToMapCount(user_b.getBio());
+    currentUser.addNewBioToMapCount(user_d.getBio());
 
-//       Collection<User> newMatches = new HashSet<User>();
-//       newMatches.add(user_forward);
-//       newMatches.add(user_forward_repeat);
+    Collection<User> newMatches = new HashSet<User>();
+    newMatches.add(user_forward);
+    newMatches.add(user_forward_repeat);
 
-//       Map<User, Double> matchScores = MatchRanking.getMatchScores(savedMatches, newMatches);
+    Map<User, Double> matchScores = MatchRanking.getMatchScores(currentUser.getBioMap(), newMatches);
       
-//       Assert.assertTrue(compareDoubles(matchScores.get(user_forward), matchScores.get(user_forward_repeat)));
-//   }
+    Assert.assertTrue(compareDoubles(matchScores.get(user_forward), matchScores.get(user_forward_repeat)));
+  }
 
-//   //a long user bio that has the word "security" a lot should be ranked higher than the user with "security" once
-//   @Test
-//   public void longBioWithKeywordTest() {
-//       Collection<User> savedMatches = new HashSet<User>();
-//       savedMatches.add(user_d);
-//       savedMatches.add(user_e);
-//       savedMatches.add(user_forward);
-//       savedMatches.add(user_backward);
+  //a long user bio that has the word "security" a lot should be ranked higher than the user with "security" once
+  @Test
+  public void longBioWithKeywordTest() {
+    User currentUser = new User("");
+    currentUser.addNewBioToMapCount(user_d.getBio());
+    currentUser.addNewBioToMapCount(user_e.getBio());
+    currentUser.addNewBioToMapCount(user_forward.getBio());
+    currentUser.addNewBioToMapCount(user_backward.getBio());
 
-//       Collection<User> newMatches = new HashSet<User>();
-//       newMatches.add(user_a);
-//       newMatches.add(user_long_security);
+    Collection<User> newMatches = new HashSet<User>();
+    newMatches.add(user_a);
+    newMatches.add(user_long_security);
 
-//       List<User> expected = new ArrayList<User>();
-//       expected.add(user_long_security);
-//       expected.add(user_a);
+    List<User> expected = new ArrayList<User>();
+    expected.add(user_long_security);
+    expected.add(user_a);
 
-//       List<User> result = MatchRanking.rankMatches(savedMatches, newMatches);
-//       Assert.assertEquals(expected, result);
-//   }
+    List<User> result = MatchRanking.rankMatches(currentUser.getBioMap(), newMatches);
+    Assert.assertEquals(expected, result);
+  }
 
-//   //compares two users with the same words, but one with two of every word and makes sure that they have the same score
-//   @Test
-//   public void nthRootTest() {
-//       Collection<User> savedMatches = new HashSet<User>();
-//       savedMatches.add(user_d);
-//       savedMatches.add(user_e);
+  //compares two users with the same words, but one with two of every word and makes sure that they have the same score
+  @Test
+  public void nthRootTest() {
+    User currentUser = new User("");
+    currentUser.addNewBioToMapCount(user_d.getBio());
+    currentUser.addNewBioToMapCount(user_e.getBio());
 
-//       Collection<User> newMatches = new HashSet<User>();
-//       newMatches.add(user_a);
-//       newMatches.add(user_a_doubled);
+    Collection<User> newMatches = new HashSet<User>();
+    newMatches.add(user_a);
+    newMatches.add(user_a_doubled);
 
-//       Map<User, Double> matchScores = MatchRanking.getMatchScores(savedMatches, newMatches);
+    Map<User, Double> matchScores = MatchRanking.getMatchScores(currentUser.getBioMap(), newMatches);
 
-//       Assert.assertTrue(compareDoubles(matchScores.get(user_a), matchScores.get(user_a_doubled)));
-//   }
+    Assert.assertTrue(compareDoubles(matchScores.get(user_a), matchScores.get(user_a_doubled)));
+  }
 
-//   //helper method to compare doubles used in some tests
-//   private static boolean compareDoubles(double d1, double d2) {
-//     return (Math.abs(d1 - d2) < 0.0001);
-//   }
+  //helper method to compare doubles used in some tests
+  private static boolean compareDoubles(double d1, double d2) {
+    return (Math.abs(d1 - d2) < 0.0001);
+  }
 
 }

--- a/src/test/java/com/google/sps/MatchServletTest.java
+++ b/src/test/java/com/google/sps/MatchServletTest.java
@@ -30,6 +30,9 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+
+import java.util.*;
+
 public class MatchServletTest {
 
     private HttpServletRequest request;
@@ -150,8 +153,8 @@ public class MatchServletTest {
 
     //count number of opening brackets in result string, which is equal to number of matches
     private int matchesInString(String result) {
-        int numMatches = (result.length() - result.replace("{", "").length());
-        return numMatches;
+        User[] userArray = gson.fromJson(result, User[].class);  
+        return userArray.length;
     }
 
 }

--- a/src/test/java/com/google/sps/NewMatchQueryServletTest.java
+++ b/src/test/java/com/google/sps/NewMatchQueryServletTest.java
@@ -1,93 +1,93 @@
-// package com.google.sps;
+package com.google.sps;
 
-// import static org.mockito.Mockito.when;
-// import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 
-// import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
-// import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
-// import com.google.gson.Gson;
-// import com.google.sps.algorithms.MatchQuery;
-// import com.google.sps.data.MatchRepository;
-// import com.google.sps.data.MatchRequest;
-// import com.google.sps.data.PersistentMatchRepository;
-// import com.google.sps.data.PersistentUserRepository;
-// import com.google.sps.data.SessionContext;
-// import com.google.sps.data.User;
-// import com.google.sps.data.UserRepository;
-// import com.google.sps.servlets.MatchServlet;
-// import com.google.sps.servlets.NewMatchQueryServlet;
-// import java.io.IOException;
-// import java.io.PrintWriter;
-// import java.io.StringWriter;
-// import java.util.ArrayList;
-// import java.util.Collection;
-// import javax.servlet.ServletConfig;
-// import javax.servlet.ServletContext;
-// import javax.servlet.ServletException;
-// import javax.servlet.http.HttpServletRequest;
-// import javax.servlet.http.HttpServletResponse;
-// import org.junit.After;
-// import org.junit.Assert;
-// import org.junit.Before;
-// import org.junit.Test;
-// import org.mockito.Mock;
-// import org.mockito.Mockito;
-// import org.mockito.MockitoAnnotations;
-// public class NewMatchQueryServletTest {
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.gson.Gson;
+import com.google.sps.algorithms.MatchQuery;
+import com.google.sps.data.MatchRepository;
+import com.google.sps.data.MatchRequest;
+import com.google.sps.data.PersistentMatchRepository;
+import com.google.sps.data.PersistentUserRepository;
+import com.google.sps.data.SessionContext;
+import com.google.sps.data.User;
+import com.google.sps.data.UserRepository;
+import com.google.sps.servlets.MatchServlet;
+import com.google.sps.servlets.NewMatchQueryServlet;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+public class NewMatchQueryServletTest {
 
-//     private HttpServletRequest request;
-//     private HttpServletResponse response;
-//     private UserRepository userRepository;
-//     // = PersistentUserRepository.getInstance();
-//     private User testUser;
-//     private Gson gson;
-//     private NewMatchQueryServlet newMatchQueryServlet;
-//     private SessionContext sessionContext;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private UserRepository userRepository;
+    // = PersistentUserRepository.getInstance();
+    private User testUser;
+    private Gson gson;
+    private NewMatchQueryServlet newMatchQueryServlet;
+    private SessionContext sessionContext;
 
-//     private LocalServiceTestHelper localHelper =
-//     new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+    private LocalServiceTestHelper localHelper =
+    new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
 
-//     @Before
-//     public void setup() {
-//         localHelper.setUp();
-//         request = Mockito.mock(HttpServletRequest.class); 
-//         response = Mockito.mock(HttpServletResponse.class);
-//         sessionContext = Mockito.mock(SessionContext.class);
-//         testUser = new User("Test User");
-//         testUser.setId("000");
-//         testUser.setEmail("test@example.com");
+    @Before
+    public void setup() {
+        localHelper.setUp();
+        request = Mockito.mock(HttpServletRequest.class); 
+        response = Mockito.mock(HttpServletResponse.class);
+        sessionContext = Mockito.mock(SessionContext.class);
+        testUser = new User("Test User");
+        testUser.setId("000");
+        testUser.setEmail("test@example.com");
 
-//         userRepository = PersistentUserRepository.getInstance();
+        userRepository = PersistentUserRepository.getInstance();
 
-//         gson = new Gson();
-//         newMatchQueryServlet = new NewMatchQueryServlet();
-//         newMatchQueryServlet.testOnlySetContext(sessionContext);
-//     }
+        gson = new Gson();
+        newMatchQueryServlet = new NewMatchQueryServlet();
+        newMatchQueryServlet.testOnlySetContext(sessionContext);
+    }
 
-//     @After
-//     public void tearDown() throws Exception {
-//         localHelper.tearDown();
-//     }
+    @After
+    public void tearDown() throws Exception {
+        localHelper.tearDown();
+    }
 
-//     @Test
-//     public void doPost_returnsNewMatches() throws IOException, ServletException {
-//         when(sessionContext.getLoggedInUser()).thenReturn(testUser);
+    @Test
+    public void doPost_returnsNewMatches() throws IOException, ServletException {
+        when(sessionContext.getLoggedInUser()).thenReturn(testUser);
 
-//         MatchQuery matchQuery = new MatchQuery();
-//         Collection<User> userSavedMatches = new ArrayList<User>();
-//         Collection<User> answer = matchQuery.query(new MatchRequest(), userSavedMatches);
+        MatchQuery matchQuery = new MatchQuery();
+        Collection<User> userSavedMatches = new ArrayList<User>();
+        Collection<User> answer = matchQuery.query(testUser, new MatchRequest(), userSavedMatches);
  
-//         StringWriter StringWriter = new StringWriter();
-//         PrintWriter printWriter = new PrintWriter(StringWriter);
-//         when(response.getWriter()).thenReturn(printWriter);
+        StringWriter StringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(StringWriter);
+        when(response.getWriter()).thenReturn(printWriter);
 
-//         newMatchQueryServlet.doPost(request, response);
+        newMatchQueryServlet.doPost(request, response);
 
-//         Gson gson = new Gson();
-//         String expected = gson.toJson(answer);
-//         String result = StringWriter.getBuffer().toString().trim();
+        Gson gson = new Gson();
+        String expected = gson.toJson(answer);
+        String result = StringWriter.getBuffer().toString().trim();
 
-//         printWriter.flush();
-//         Assert.assertEquals(expected, result);
-//     }
-// }
+        printWriter.flush();
+        Assert.assertEquals(expected, result);
+    }
+}

--- a/src/test/java/com/google/sps/NewMatchQueryServletTest.java
+++ b/src/test/java/com/google/sps/NewMatchQueryServletTest.java
@@ -1,93 +1,93 @@
-package com.google.sps;
+// package com.google.sps;
 
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
+// import static org.mockito.Mockito.when;
+// import static org.mockito.Mockito.mock;
 
-import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
-import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
-import com.google.gson.Gson;
-import com.google.sps.algorithms.MatchQuery;
-import com.google.sps.data.MatchRepository;
-import com.google.sps.data.MatchRequest;
-import com.google.sps.data.PersistentMatchRepository;
-import com.google.sps.data.PersistentUserRepository;
-import com.google.sps.data.SessionContext;
-import com.google.sps.data.User;
-import com.google.sps.data.UserRepository;
-import com.google.sps.servlets.MatchServlet;
-import com.google.sps.servlets.NewMatchQueryServlet;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Collection;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-public class NewMatchQueryServletTest {
+// import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+// import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+// import com.google.gson.Gson;
+// import com.google.sps.algorithms.MatchQuery;
+// import com.google.sps.data.MatchRepository;
+// import com.google.sps.data.MatchRequest;
+// import com.google.sps.data.PersistentMatchRepository;
+// import com.google.sps.data.PersistentUserRepository;
+// import com.google.sps.data.SessionContext;
+// import com.google.sps.data.User;
+// import com.google.sps.data.UserRepository;
+// import com.google.sps.servlets.MatchServlet;
+// import com.google.sps.servlets.NewMatchQueryServlet;
+// import java.io.IOException;
+// import java.io.PrintWriter;
+// import java.io.StringWriter;
+// import java.util.ArrayList;
+// import java.util.Collection;
+// import javax.servlet.ServletConfig;
+// import javax.servlet.ServletContext;
+// import javax.servlet.ServletException;
+// import javax.servlet.http.HttpServletRequest;
+// import javax.servlet.http.HttpServletResponse;
+// import org.junit.After;
+// import org.junit.Assert;
+// import org.junit.Before;
+// import org.junit.Test;
+// import org.mockito.Mock;
+// import org.mockito.Mockito;
+// import org.mockito.MockitoAnnotations;
+// public class NewMatchQueryServletTest {
 
-    private HttpServletRequest request;
-    private HttpServletResponse response;
-    private UserRepository userRepository;
-    // = PersistentUserRepository.getInstance();
-    private User testUser;
-    private Gson gson;
-    private NewMatchQueryServlet newMatchQueryServlet;
-    private SessionContext sessionContext;
+//     private HttpServletRequest request;
+//     private HttpServletResponse response;
+//     private UserRepository userRepository;
+//     // = PersistentUserRepository.getInstance();
+//     private User testUser;
+//     private Gson gson;
+//     private NewMatchQueryServlet newMatchQueryServlet;
+//     private SessionContext sessionContext;
 
-    private LocalServiceTestHelper localHelper =
-    new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+//     private LocalServiceTestHelper localHelper =
+//     new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
 
-    @Before
-    public void setup() {
-        localHelper.setUp();
-        request = Mockito.mock(HttpServletRequest.class); 
-        response = Mockito.mock(HttpServletResponse.class);
-        sessionContext = Mockito.mock(SessionContext.class);
-        testUser = new User("Test User");
-        testUser.setId("000");
-        testUser.setEmail("test@example.com");
+//     @Before
+//     public void setup() {
+//         localHelper.setUp();
+//         request = Mockito.mock(HttpServletRequest.class); 
+//         response = Mockito.mock(HttpServletResponse.class);
+//         sessionContext = Mockito.mock(SessionContext.class);
+//         testUser = new User("Test User");
+//         testUser.setId("000");
+//         testUser.setEmail("test@example.com");
 
-        userRepository = PersistentUserRepository.getInstance();
+//         userRepository = PersistentUserRepository.getInstance();
 
-        gson = new Gson();
-        newMatchQueryServlet = new NewMatchQueryServlet();
-        newMatchQueryServlet.testOnlySetContext(sessionContext);
-    }
+//         gson = new Gson();
+//         newMatchQueryServlet = new NewMatchQueryServlet();
+//         newMatchQueryServlet.testOnlySetContext(sessionContext);
+//     }
 
-    @After
-    public void tearDown() throws Exception {
-        localHelper.tearDown();
-    }
+//     @After
+//     public void tearDown() throws Exception {
+//         localHelper.tearDown();
+//     }
 
-    @Test
-    public void doPost_returnsNewMatches() throws IOException, ServletException {
-        when(sessionContext.getLoggedInUser()).thenReturn(testUser);
+//     @Test
+//     public void doPost_returnsNewMatches() throws IOException, ServletException {
+//         when(sessionContext.getLoggedInUser()).thenReturn(testUser);
 
-        MatchQuery matchQuery = new MatchQuery();
-        Collection<User> userSavedMatches = new ArrayList<User>();
-        Collection<User> answer = matchQuery.query(new MatchRequest(), userSavedMatches);
+//         MatchQuery matchQuery = new MatchQuery();
+//         Collection<User> userSavedMatches = new ArrayList<User>();
+//         Collection<User> answer = matchQuery.query(new MatchRequest(), userSavedMatches);
  
-        StringWriter StringWriter = new StringWriter();
-        PrintWriter printWriter = new PrintWriter(StringWriter);
-        when(response.getWriter()).thenReturn(printWriter);
+//         StringWriter StringWriter = new StringWriter();
+//         PrintWriter printWriter = new PrintWriter(StringWriter);
+//         when(response.getWriter()).thenReturn(printWriter);
 
-        newMatchQueryServlet.doPost(request, response);
+//         newMatchQueryServlet.doPost(request, response);
 
-        Gson gson = new Gson();
-        String expected = gson.toJson(answer);
-        String result = StringWriter.getBuffer().toString().trim();
+//         Gson gson = new Gson();
+//         String expected = gson.toJson(answer);
+//         String result = StringWriter.getBuffer().toString().trim();
 
-        printWriter.flush();
-        Assert.assertEquals(expected, result);
-    }
-}
+//         printWriter.flush();
+//         Assert.assertEquals(expected, result);
+//     }
+// }


### PR DESCRIPTION
Improving the runtime of my ML algorithm (row 16 OKR)

I am now storing a static Map in the MatchRanking class for all-user word counts, and a Map in each User for user-saved-matches word counts. 

UPDATE: I'm not sure that this is actually working when deployed because the maps aren't stored in a persistent repo... I will continue to test this tomorrow but it doesn't seem to work at the moment